### PR TITLE
Fix portal.api's #18

### DIFF
--- a/src/InfrastructureAdd.html
+++ b/src/InfrastructureAdd.html
@@ -1,4 +1,4 @@
-<div class="page-header" >
+g<div class="page-header" >
 	<div class="container">
 		<div class="row">
 			<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
@@ -13,11 +13,20 @@
 						</div>
 					</div>
 					<div class="form-group">
-						<label for="portalinfrastructure.datacentername" class="col-sm-2 control-label">VIM's MANO Provider Name</label>
+						<label for="manoProviderSelect" class="col-sm-2 control-label">Select a MANO Provider:</label>
 						<div class="col-sm-10">
-							<input type="text" class="form-control"  ng-model="portalinfrastructure.datacentername" value="" placeholder="VIM's MANO Provider Name..." />
+						  <select class="form-control" id="manoProviderSelect" ng-model="portalinfrastructure.mp" ng-options="(manoprovider.id + ' - ' + manoprovider.name) for manoprovider in manoproviders" ng-change="updateDatacentername()">
+						  </select>
 						</div>
-					</div>					
+					  </div>
+					  <div class="form-group">
+						<label for="portalinfrastructure.datacentername" class="col-sm-2 control-label">Datacenter VIM Name</label>
+						<div class="col-sm-10">
+						  <input type="text" class="form-control" ng-model="portalinfrastructure.datacentername"
+								 ng-disabled="true"
+								 placeholder="Datacenter VIM name..." />
+						</div>
+					  </div>					
 					<div class="form-group">
 						<label for="organization" class="col-sm-2 control-label">Organization</label>
 						<div class="col-sm-10">

--- a/src/InfrastructureAdd.html
+++ b/src/InfrastructureAdd.html
@@ -1,4 +1,4 @@
-g<div class="page-header" >
+<div class="page-header" >
 	<div class="container">
 		<div class="row">
 			<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">

--- a/src/InfrastructureEdit.html
+++ b/src/InfrastructureEdit.html
@@ -5,7 +5,7 @@
 				<h1 id="headerTitle">Edit Infrastructure</h1>				
 				
 				<a class="btn btn-success btn-lg" data-toggle="modal" ng-href="#!/vim_vfimage_add/{{portalinfrastructure.id}}"> 
-				<i class="fa fa-database fa-2x pull-left"></i>&nbsp;&nbsp;Add Supported<br>Image</a>
+				<i class="fa fa-datsabase fa-2x pull-left"></i>&nbsp;&nbsp;Add Supported<br>Image</a>
 				<h2/>
 				<form name="form" class="form-horizontal" role="form" ng-submit="updateInfrastructure()" id="editUserForm">
 					<input type="hidden" name="userid" value="" />
@@ -17,11 +17,20 @@
 					</div>
 					
 					<div class="form-group">
-						<label for="portalinfrastructure.datacentername" class="col-sm-2 control-label">VIM's MANO Provider Name</label>
+						<label for="manoProviderSelect" class="col-sm-2 control-label">Select a MANO Provider:</label>
 						<div class="col-sm-10">
-							<input type="text" class="form-control"  ng-model="portalinfrastructure.datacentername" value="" placeholder="VIM's MANO Provider Name..." />
+						  <select class="form-control" id="manoProviderSelect" ng-model="portalinfrastructure.mp" ng-options="(manoprovider.id + ' - ' + manoprovider.name) for manoprovider in manoproviders" ng-change="editDatacentername()">
+						  </select>
 						</div>
-					</div>
+					  </div>
+					  <div class="form-group">
+						<label for="portalinfrastructure.datacentername" class="col-sm-2 control-label">Datacenter VIM Name</label>
+						<div class="col-sm-10">
+						  <input type="text" class="form-control" ng-model="portalinfrastructure.datacentername"
+								 ng-disabled="true"
+								 placeholder="Datacenter VIM name..." />
+						</div>
+					  </div>
 					
 
 					<div class="form-group">

--- a/src/InfrastructureEdit.html
+++ b/src/InfrastructureEdit.html
@@ -5,7 +5,7 @@
 				<h1 id="headerTitle">Edit Infrastructure</h1>				
 				
 				<a class="btn btn-success btn-lg" data-toggle="modal" ng-href="#!/vim_vfimage_add/{{portalinfrastructure.id}}"> 
-				<i class="fa fa-datsabase fa-2x pull-left"></i>&nbsp;&nbsp;Add Supported<br>Image</a>
+				<i class="fa fa-database fa-2x pull-left"></i>&nbsp;&nbsp;Add Supported<br>Image</a>
 				<h2/>
 				<form name="form" class="form-horizontal" role="form" ng-submit="updateInfrastructure()" id="editUserForm">
 					<input type="hidden" name="userid" value="" />

--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -2708,24 +2708,48 @@ appControllers.controller('InfrastructureListController', ['$scope','$window','$
 	
 
 
-appControllers.controller('InfrastructureAddController',function($scope, $location, Infrastructure){
+appControllers.controller('InfrastructureAddController',  ['$scope','$window','$log', '$location', 'Infrastructure', 'AdminMANOprovider', function($scope, $window, $log, $location, Infrastructure, AdminMANOprovider){
 
     $scope.portalinfrastructure=new Infrastructure();
+	
+	$scope.manoproviders = AdminMANOprovider.query(function() {
+		
+		//console.log($scope.categories);
+	  }); //query() returns all the categories
+	console.log($scope.manoproviders)
+	$scope.updateDatacentername = function() {
+		console.log("portalinfrastructure.mp.name = " + $scope.portalinfrastructure.mp.name );
+		
+		$scope.portalinfrastructure.datacentername =  $scope.portalinfrastructure.mp.name
+		console.log("portalinfrastructure.datacentername = " + $scope.portalinfrastructure.datacentername );
+		
+				
+  }
 
     $scope.addInfrastructure =function(){
+		
+
         $scope.portalinfrastructure.$save(function(){
 			$location.path("/infrastructures");
         });
     }
 
-});
+}]);
 
-appControllers.controller('InfrastructureEditController', ['$scope', '$route', '$routeParams', '$location', 'Infrastructure', '$anchorScroll',
-        function( $scope, $route, $routeParams, $location, Infrastructure, $anchorScroll){
+appControllers.controller('InfrastructureEditController', ['$scope', '$window', '$log', '$location', '$route', '$routeParams', 'Infrastructure', '$anchorScroll', 'AdminMANOprovider',
+        function( $scope, $window, $log, $location, $route, $routeParams, Infrastructure, $anchorScroll, AdminMANOprovider){
 
-
-    //console.log("WILL EDIT User with ID "+$routeParams.id);
 	
+	$scope.manoproviders = AdminMANOprovider.query(function() {
+    //console.log("WILL EDIT User with ID "+$routeParams.id);
+	});
+	console.log($scope.manoproviders)
+	$scope.editDatacentername = function() {
+		console.log("portalinfrastructure.mp.name = " + $scope.portalinfrastructure.mp.name );
+		
+		$scope.portalinfrastructure.datacentername =  $scope.portalinfrastructure.mp.name
+		console.log("portalinfrastructure.datacentername = " + $scope.portalinfrastructure.datacentername );
+	}	
     $scope.updateInfrastructure=function(){
     	
         $scope.portalinfrastructure.$update(function(){


### PR DESCRIPTION
This fix is related to the issue [#18](https://github.com/openslice/io.openslice.portal.api/issues/18) presented in portal.api. With this feature the user is able to associate the MANO Provider with the VIM when creating or adding them. Bellow there are presented the screenshots of the new additions. The VIM DataCenter Name will automatically be changed to the name of the MANO Provider Choosen, as it was the previous logic of the Code.
![Screenshot 2023-10-03 at 16 37 47](https://github.com/openslice/io.openslice.portal.web/assets/48451636/79d61453-ac6e-4e27-a681-8abc5eb2f8a3)
![Screenshot 2023-10-03 at 16 37 57](https://github.com/openslice/io.openslice.portal.web/assets/48451636/606e1260-e811-43f5-b754-94fc59534fcf)
![Screenshot 2023-10-03 at 17 08 43](https://github.com/openslice/io.openslice.portal.web/assets/48451636/29925610-d6f0-420d-890a-7bd4d986d8ec)
